### PR TITLE
changed the deleteLineItem to take the first instance of the line item

### DIFF
--- a/Controllers/CartController.cs
+++ b/Controllers/CartController.cs
@@ -111,7 +111,7 @@ namespace BangazonWeb.Controllers
                 select order).SingleOrDefaultAsync();  
             
 
-            LineItem deletedItem = await context.LineItem.SingleAsync(p => p.ProductId == id && p.OrderId == OpenOrder.OrderId);
+            LineItem deletedItem = await context.LineItem.FirstAsync(p => p.ProductId == id && p.OrderId == OpenOrder.OrderId);
 
 
             if (deletedItem == null)

--- a/Controllers/ProductSubTypesController.cs
+++ b/Controllers/ProductSubTypesController.cs
@@ -6,7 +6,6 @@ using System.Threading.Tasks;
 using BangazonWeb.Data;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
-using Bangazon.Helpers;
 using BangazonWeb.ViewModels;
 
 namespace BangazonWeb.Controllers


### PR DESCRIPTION
## Status
**READY**

## Documentation

[ ] I have fully documented features in this PR's code. Please put an `X` in the box to confirm.

[X] This PR does **NOT** require documentation.

## Description
A few sentences describing the overall goals of the pull request's commits.

There was a bug that would happen when there were duplicate items in a cart, now the delete lineitem function takes the first instance that matches the lync query, this ensures that the error will not be thrown 

## Resolves Issue Number

#147 

## Deploy Notes
Notes regarding deployment the contained body of work.  These should note any
db migrations, etc.

```sh
git pull --prune
git checkout 147-delete-line-item
dotnet run
```

## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.

1. Add two of anything to your cart.
2. View your cart
3. Delete one of the duplicates from your cart. 


## Impacted Files in Application
List general components of the application that this PR will affect:

* CartController.cs

