### PR TITLE
Complete order button disabled

### DIFF
--- a/Migrations/20161031234645_initial.Designer.cs
+++ b/Migrations/20161031234645_initial.Designer.cs
@@ -8,8 +8,8 @@ using BangazonWeb.Data;
 namespace initialsite.Migrations
 {
     [DbContext(typeof(BangazonContext))]
-    [Migration("20161031181638_InitialCreate")]
-    partial class InitialCreate
+    [Migration("20161031234645_initial")]
+    partial class initial
     {
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {

--- a/Migrations/20161031234645_initial.cs
+++ b/Migrations/20161031234645_initial.cs
@@ -4,7 +4,7 @@ using Microsoft.EntityFrameworkCore.Migrations;
 
 namespace initialsite.Migrations
 {
-    public partial class InitialCreate : Migration
+    public partial class initial : Migration
     {
         protected override void Up(MigrationBuilder migrationBuilder)
         {

--- a/Views/Order/Final.cshtml
+++ b/Views/Order/Final.cshtml
@@ -18,9 +18,19 @@
 </div>
 }
 <h2>TOTAL: $@Model.TotalPrice</h2>
-<form asp-controller="Cart" asp-action="CompleteOrder">
-@Html.DropDownList("selectedPaymentId", @Model.AvailablePaymentType, "SELECT" , new { @class = "dropdown" })
 
-<a  class="btn btn-primary" asp-controller="PaymentTypes" asp-action="Create">Create Payment Type</a>
-<input type="submit" value="Complete Order" id="checkoutButton" disabled asp-controller="Cart" asp-action="CompleteOrder" class="btn btn-primary" />
-</form>
+<div class="row">
+    <div class="row">
+        <h4>Please Select Your Payment Type</h4>
+    </div>
+    <div class="row">
+        <form asp-controller="Cart" asp-action="CompleteOrder">
+            <div class="col-md-6">
+                @Html.DropDownList("selectedPaymentId", @Model.AvailablePaymentType, "SELECT" , new { @class = "form-control" })
+            </div>
+            <div class="col-md-6">
+                <a  class="btn btn-primary" asp-controller="PaymentTypes" asp-action="Create">Create Payment Type</a>
+                <input type="submit" value="Complete Order" id="checkoutButton" disabled asp-controller="Cart" asp-action="CompleteOrder" class="btn btn-primary" />
+        </form>
+    </div>
+</div>

--- a/Views/Order/Final.cshtml
+++ b/Views/Order/Final.cshtml
@@ -22,5 +22,5 @@
 @Html.DropDownList("selectedPaymentId", @Model.AvailablePaymentType, "SELECT" , new { @class = "dropdown" })
 
 <a  class="btn btn-primary" asp-controller="PaymentTypes" asp-action="Create">Create Payment Type</a>
-<input type="submit" value="Complete Order" id="checkoutButton" asp-controller="Cart" asp-action="CompleteOrder" class="btn btn-primary" />
+<input type="submit" value="Complete Order" id="checkoutButton" disabled asp-controller="Cart" asp-action="CompleteOrder" class="btn btn-primary" />
 </form>

--- a/wwwroot/js/site.js
+++ b/wwwroot/js/site.js
@@ -31,13 +31,18 @@ $(document).ready(function () {
 
   // disable the Checkout button until a PaymentType has been selected
   if ($("#selectedPaymentId").val() == 0) {
-    $("#checkoutButton").hide();
+      $("#checkoutButton").prop("disabled", true);
+  }
+  else {
+      $("#checkoutButton").removeAttr("disabled");
   }
   $("#selectedPaymentId").on("change",function(){
     if ($("#selectedPaymentId").val() > 0) {
-      $("#checkoutButton").show();
-    } else {
-      $("#checkoutButton").hide();
+      $("#checkoutButton").removeAttr("disabled");
+    } 
+    else if ($("#selectedPaymentId").val() == 0)
+    {
+      $("#checkoutButton").prop("disabled", true);
     }
   })
 


### PR DESCRIPTION
## Status
**READY/IN DEVELOPMENT**

## Documentation

[ x] I have fully documented features in this PR's code. Please put an `X` in the box to confirm.

[ ] This PR does **NOT** require documentation.

## Description
The Complete Order Button on the Order/Final view is disabled as long as the dropdownlist value is 0.
Little Page Styling

## Resolves Issue Number

## Deploy Notes
```sh
git pull --prune
git checkout <Complete-Order-Button-Disabled>
dotnet run
```

## Steps to Test or Reproduce

1. Select a user.
2. Add an Item to the cart.
3. Go to the cart and the complete order button should be disabled.
4. Select a Payment Type and the button will be enabled.
5. Create a New Payment Type and come back to the page and the button will be enabled due to the
default selection of the new payment type in the dropdownlist

## Impacted Files in Application
Site.Js . Final.cshtml

* 
